### PR TITLE
feat(api): API キーのエディタと型変換を追加

### DIFF
--- a/Shine/AiAssistantOptions.cs
+++ b/Shine/AiAssistantOptions.cs
@@ -30,6 +30,8 @@ namespace Shine
         [Category("OpenAI")]
         [DisplayName("API キー")]
         [Description("OpenAI API の API キーを入力します。")]
+        [TypeConverter(typeof(ApiKeyTypeConverter))]
+        [Editor(typeof(ApiKeyEditor), typeof(System.Drawing.Design.UITypeEditor))]
         public string OpenAIApiKey { get; set; } = "sk-";
 
         [Category("OpenAI")]
@@ -68,6 +70,8 @@ namespace Shine
         [Category("Azure OpenAI")]
         [DisplayName("API キー")]
         [Description("Azure OpenAI の API キーを入力します。")]
+        [TypeConverter(typeof(ApiKeyTypeConverter))]
+        [Editor(typeof(ApiKeyEditor), typeof(System.Drawing.Design.UITypeEditor))]
         public string AzureOpenAIApiKey { get; set; } = "azure-api-key";
 
         [Category("Azure OpenAI")]

--- a/Shine/Helpers/ApiKeyEditor.cs
+++ b/Shine/Helpers/ApiKeyEditor.cs
@@ -1,0 +1,89 @@
+﻿// ファイル名: ApiKeyEditor.cs
+using System;
+using System.ComponentModel;
+using System.Drawing.Design;
+using System.Windows.Forms;
+using System.Windows.Forms.Design;
+
+namespace Shine
+{
+    /// <summary>
+    /// API キーをマスク／アンマスクできるプロパティ エディタ
+    /// ・ドロップダウン開いた直後は「****************」を表示
+    /// ・「表示」チェックで本物のキーを表示
+    /// </summary>
+    public class ApiKeyEditor : UITypeEditor
+    {
+        // グリッド上でもエディタ内でも使う固定マスク文字列
+        private const string _mask = "****************";
+
+        public override UITypeEditorEditStyle GetEditStyle(ITypeDescriptorContext context)
+            => UITypeEditorEditStyle.DropDown;
+
+        public override object EditValue(ITypeDescriptorContext context, IServiceProvider provider, object value)
+        {
+            if (provider?.GetService(typeof(IWindowsFormsEditorService))
+                is not IWindowsFormsEditorService svc)
+                return value;
+
+            // オリジナルのキーを覚えておく
+            string original = value as string ?? string.Empty;
+
+            // ドロップダウン用パネル
+            var panel = new Panel
+            {
+                Width = 500,
+                Height = 60
+            };
+
+            // テキストボックス（最初は固定マスクを表示）
+            var tb = new TextBox
+            {
+                Parent = panel,
+                Text = _mask,
+                UseSystemPasswordChar = false, // 星を文字列として見せる
+                Width = 500,
+                Left = 0,
+                Top = 0
+            };
+
+            // マスク解除用チェックボックス
+            var chk = new CheckBox
+            {
+                Parent = panel,
+                Text = "表示",
+                AutoSize = true,
+                Left = 0,
+                Top = tb.Bottom + 6,
+                Checked = false
+            };
+
+            chk.CheckedChanged += (_, __) =>
+            {
+                if (chk.Checked)
+                {
+                    // チェックON → 本物のキーを表示
+                    tb.Text = original;
+                    tb.UseSystemPasswordChar = false;
+                }
+                else
+                {
+                    // チェックOFF → 再び固定マスク表示
+                    tb.Text = _mask;
+                    tb.UseSystemPasswordChar = false;
+                }
+            };
+
+            // ドロップダウンを表示
+            svc.DropDownControl(panel);
+
+            // ドロップダウンを閉じた後、返す値を決定
+            // ・ユーザーが何も触らず閉じた（tb.Text == Mask）→ 元のキーを返す
+            // ・tb.Text != Mask → ユーザーが新しいキーを入力した可能性 → その文字列を返す
+            if (tb.Text == _mask)
+                return original;
+            else
+                return tb.Text;
+        }
+    }
+}

--- a/Shine/Helpers/ApiKeyTypeConverter.cs
+++ b/Shine/Helpers/ApiKeyTypeConverter.cs
@@ -1,0 +1,23 @@
+﻿// ファイル名: ApiKeyTypeConverter.cs
+using System;
+using System.ComponentModel;
+using System.Globalization;
+
+namespace Shine
+{
+    public class ApiKeyTypeConverter : StringConverter
+    {
+        public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
+            => destinationType == typeof(string) || base.CanConvertTo(context, destinationType);
+
+        public override object ConvertTo(ITypeDescriptorContext context, CultureInfo culture, object value, Type destinationType)
+        {
+            if (destinationType == typeof(string))
+            {
+                // グリッド上では必ず固定マスク文字列を返す
+                return "******************";
+            }
+            return base.ConvertTo(context, culture, value, destinationType);
+        }
+    }
+}

--- a/Shine/Shine.csproj
+++ b/Shine/Shine.csproj
@@ -67,6 +67,8 @@
     <Compile Include="ClientServices\OpenAI\O4ChatModelProcessor.cs" />
     <Compile Include="GitServices\GitDiffHelper.cs" />
     <Compile Include="GitServices\GitDiffSummarizer.cs" />
+    <Compile Include="Helpers\ApiKeyEditor.cs" />
+    <Compile Include="Helpers\ApiKeyTypeConverter.cs" />
     <Compile Include="Helpers\BrushHelper.cs" />
     <Compile Include="Chat\ChatHistoryDocument.cs" />
     <Compile Include="Chat\ChatMessageFormatter.cs" />


### PR DESCRIPTION
`AiAssistantOptions.cs` に OpenAI および Azure OpenAI の API キー用のカスタムエディタを追加しました。 `ApiKeyEditor.cs` では、API キーをマスクおよびアンマスクする機能を実装し、ユーザーがキーを表示または隠すことができるチェックボックスを提供します。 `ApiKeyTypeConverter.cs` では、API キーの型変換を行い、グリッド上で常にマスクされた文字列を返すように設定しました。 `Shine.csproj` において、これらのファイルをプロジェクトに追加し、コンパイル対象として指定しました。