### PR TITLE
feat(AiAssistant): API キーのマスク表示と新コマンド追加

### DIFF
--- a/Shine/AiAssistantOptions.cs
+++ b/Shine/AiAssistantOptions.cs
@@ -30,8 +30,7 @@ namespace Shine
         [Category("OpenAI")]
         [DisplayName("API キー")]
         [Description("OpenAI API の API キーを入力します。")]
-        [TypeConverter(typeof(ApiKeyTypeConverter))]
-        [Editor(typeof(ApiKeyEditor), typeof(System.Drawing.Design.UITypeEditor))]
+        [PasswordPropertyText(true)]
         public string OpenAIApiKey { get; set; } = "sk-";
 
         [Category("OpenAI")]
@@ -70,8 +69,7 @@ namespace Shine
         [Category("Azure OpenAI")]
         [DisplayName("API キー")]
         [Description("Azure OpenAI の API キーを入力します。")]
-        [TypeConverter(typeof(ApiKeyTypeConverter))]
-        [Editor(typeof(ApiKeyEditor), typeof(System.Drawing.Design.UITypeEditor))]
+        [PasswordPropertyText(true)]
         public string AzureOpenAIApiKey { get; set; } = "azure-api-key";
 
         [Category("Azure OpenAI")]

--- a/Shine/Helpers/ApiKeyEditor.cs
+++ b/Shine/Helpers/ApiKeyEditor.cs
@@ -1,5 +1,4 @@
-﻿// ファイル名: ApiKeyEditor.cs
-using System;
+﻿using System;
 using System.ComponentModel;
 using System.Drawing.Design;
 using System.Windows.Forms;
@@ -9,13 +8,13 @@ namespace Shine
 {
     /// <summary>
     /// API キーをマスク／アンマスクできるプロパティ エディタ
-    /// ・ドロップダウン開いた直後は「****************」を表示
+    /// ・ドロップダウン開いた直後は「******************」を表示
     /// ・「表示」チェックで本物のキーを表示
     /// </summary>
     public class ApiKeyEditor : UITypeEditor
     {
         // グリッド上でもエディタ内でも使う固定マスク文字列
-        private const string _mask = "****************";
+        private const string _mask = "******************";
 
         public override UITypeEditorEditStyle GetEditStyle(ITypeDescriptorContext context)
             => UITypeEditorEditStyle.DropDown;

--- a/Shine/Helpers/ApiKeyTypeConverter.cs
+++ b/Shine/Helpers/ApiKeyTypeConverter.cs
@@ -1,23 +1,41 @@
-﻿// ファイル名: ApiKeyTypeConverter.cs
-using System;
+﻿using System;
 using System.ComponentModel;
 using System.Globalization;
 
 namespace Shine
 {
+    /// <summary>PropertyGrid で API キーを常に固定マスク表示にする TypeConverter</summary>
     public class ApiKeyTypeConverter : StringConverter
     {
+        private const string _mask = "******************";
+
         public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
             => destinationType == typeof(string) || base.CanConvertTo(context, destinationType);
 
-        public override object ConvertTo(ITypeDescriptorContext context, CultureInfo culture, object value, Type destinationType)
+        public override object ConvertTo(ITypeDescriptorContext context, CultureInfo culture,
+                                         object value, Type destinationType)
         {
-            if (destinationType == typeof(string))
-            {
-                // グリッド上では必ず固定マスク文字列を返す
-                return "******************";
-            }
+            // 表示用は常に固定マスク
+            if (destinationType == typeof(string)) return _mask;
             return base.ConvertTo(context, culture, value, destinationType);
+        }
+
+        public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
+            => sourceType == typeof(string) || base.CanConvertFrom(context, sourceType);
+
+        public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
+        {
+            if (value is string s)
+            {
+                // ユーザーが何も編集していない場合は Mask が飛んで来る。
+                // そのときは現在値を保持し、Mask 以外なら新しいキーとして採用。
+                if (s == _mask && context?.PropertyDescriptor != null && context.Instance != null)
+                {
+                    return context.PropertyDescriptor.GetValue(context.Instance);
+                }
+                return s.Trim();
+            }
+            return base.ConvertFrom(context, culture, value);
         }
     }
 }

--- a/Shine/Shine.csproj
+++ b/Shine/Shine.csproj
@@ -102,6 +102,7 @@
     <Compile Include="Suggestion\Suggestions.cs" />
     <Compile Include="Suggestion\ThinkingAdornmentLayer.cs" />
     <Compile Include="Suggestion\ThinkingAdornmentService.cs" />
+    <Compile Include="Suggestion\TriggerSuggestionCommand.cs" />
   </ItemGroup>
   <!-- VSIX マニフェスト -->
   <ItemGroup>
@@ -116,6 +117,7 @@
     <Reference Include="PresentationFramework" />
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.DataAnnotations" />
+    <Reference Include="System.Design" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xaml" />

--- a/Shine/ShinePackage.cs
+++ b/Shine/ShinePackage.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
+using Shine.Suggestion;
 using System;
 using System.Runtime.InteropServices;
 using System.Threading;
@@ -32,16 +33,16 @@ namespace Shine
         /// <returns></returns>
         protected override async Task InitializeAsync(CancellationToken cancellationToken, IProgress<ServiceProgressData> progress)
         {
-            // UIスレッドが必要な初期化は、このメソッドの中で行います
             await this.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
-
             Instance = this;
 
-            // ツールウィンドウを表示するコマンドを初期化
+            // …コマンドの初期化…
             await ShowAiChatCommand.InitializeAsync(this);
             await AskShineFixCommand.InitializeAsync(this);
 
-            // 必要に応じて各モジュールの初期化を実施
+            // Alt+K(Suggestion)のグローバルコマンド登録
+            await TriggerSuggestionCommand.InitializeAsync(this);
+
             await base.InitializeAsync(cancellationToken, progress);
         }
     }

--- a/Shine/Suggestion/TriggerSuggestionCommand.cs
+++ b/Shine/Suggestion/TriggerSuggestionCommand.cs
@@ -1,0 +1,75 @@
+﻿// ファイル名: TriggerSuggestionCommand.cs
+using System;
+using System.ComponentModel.Design;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
+using Microsoft.VisualStudio.TextManager.Interop;
+using Microsoft.VisualStudio.Editor;
+using Microsoft.VisualStudio.ComponentModelHost;
+
+namespace Shine.Suggestion
+{
+    internal sealed class TriggerSuggestionCommand
+    {
+        // PkgCmdIDList.triggerSuggestionCommand は uint 型なので、int にキャストする
+        public const int commandId = (int)PkgCmdIDList.triggerSuggestionCommand;
+        public static readonly Guid commandSet = GuidList.guidShinePackageCmdSet;
+        private readonly AsyncPackage _package;
+
+        private TriggerSuggestionCommand(AsyncPackage package, OleMenuCommandService mcs)
+        {
+            _package = package;
+            var id = new CommandID(commandSet, commandId);
+            var cmd = new OleMenuCommand(Execute, id);
+            cmd.BeforeQueryStatus += QueryStatus;
+            mcs.AddCommand(cmd);
+        }
+
+        public static async Task InitializeAsync(AsyncPackage package)
+        {
+            // UI スレッドで登録
+            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync(package.DisposalToken);
+            var mcs = await package.GetServiceAsync(typeof(IMenuCommandService)) as OleMenuCommandService;
+            if (mcs != null)
+                new TriggerSuggestionCommand(package, mcs);
+        }
+
+        private void QueryStatus(object sender, EventArgs e)
+        {
+            var cmd = sender as OleMenuCommand;
+            // 常に有効・表示
+            cmd.Visible = cmd.Enabled = true;
+        }
+
+        private void Execute(object sender, EventArgs e)
+        {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
+            // SVsTextManager の取得
+            var textMgr = Package.GetGlobalService(typeof(SVsTextManager)) as IVsTextManager;
+            if (textMgr == null)
+                return;
+
+            textMgr.GetActiveView(1, null, out IVsTextView vsTextView);
+            if (vsTextView == null)
+                return;
+
+            // WPF テキストビューに変換
+            var componentModel = (IComponentModel)Package.GetGlobalService(typeof(SComponentModel));
+            var adapterService = componentModel.GetService<IVsEditorAdaptersFactoryService>();
+            var wpfView = adapterService.GetWpfTextView(vsTextView);
+            if (wpfView == null)
+                return;
+
+            // プロパティからマネージャーを取得して実行
+            if (wpfView.Properties.TryGetProperty<InlineSuggestionManager>("Shine.InlineSuggestionManager", out var manager))
+            {
+                if (!manager.IsBusy)
+                    _ = manager.OnEnterAsync();
+            }
+        }
+
+    }
+}


### PR DESCRIPTION
`AiAssistantOptions.cs` において、OpenAI および Azure OpenAI の API キーに `PasswordPropertyText(true)` 属性を追加し、マスク表示を実現しました。また、`ApiKeyEditor` と `ApiKeyTypeConverter` のマスク文字列を更新し、表示ロジックを改善しました。

`Shine.csproj` では、`TriggerSuggestionCommand.cs` を新たに追加し、`System.Design` への参照を追加しました。`ShinePackage.cs` では、`TriggerSuggestionCommand` の初期化を行い、AI チャットコマンドの初期化を実施しました。

`CodeSuggestionListener.cs` では、UI スレッドのチェックや WPF テキストビューの取得ロジックを整理し、可読性を向上させました。`TriggerSuggestionCommand.cs` では、新しいコマンドを定義し、ユーザーがトリガーを実行できるようにするロジックを実装しました。