### PR TITLE
refactor(InlineChatKeyFilter): メソッドの可読性向上

### DIFF
--- a/Shine/InlineChat/InlineChatKeyFilter.cs
+++ b/Shine/InlineChat/InlineChatKeyFilter.cs
@@ -2,7 +2,6 @@
 using System;
 using System.Windows.Controls;
 using System.Windows.Documents;
-using System.Windows.Input;
 using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.OLE.Interop;
 using Microsoft.VisualStudio.TextManager.Interop;
@@ -23,41 +22,59 @@ namespace Shine
             ErrorHandler.ThrowOnFailure(viewAdapter.AddCommandFilter(this, out _next));
         }
 
-        #region IOleCommandTarget
-        public int QueryStatus(ref Guid pguidCmdGroup, uint cCmds,
-                               OLECMD[] prgCmds, IntPtr pCmdText)
-            => _next?.QueryStatus(ref pguidCmdGroup, cCmds, prgCmds, pCmdText) ?? VSConstants.S_OK;
-
-        public int Exec(ref Guid pguidCmdGroup, uint nCmdID, uint nCmdexecopt,
-                        IntPtr pvaIn, IntPtr pvaOut)
+        public int QueryStatus(
+            ref Guid pguidCmdGroup,
+            uint cCmds,
+            OLECMD[] prgCmds,
+            IntPtr pCmdText)
         {
-            // ===== 1) VSStd2K コマンド（編集・カーソル） =====
+            return _next?.QueryStatus(ref pguidCmdGroup, cCmds, prgCmds, pCmdText)
+                   ?? VSConstants.S_OK;
+        }
+
+        public int Exec(
+            ref Guid pguidCmdGroup,
+            uint nCmdID,
+            uint nCmdexecopt,
+            IntPtr pvaIn,
+            IntPtr pvaOut)
+        {
+            // VSStd2K コマンド
             if (pguidCmdGroup == VSConstants.VSStd2K)
             {
                 switch ((VSConstants.VSStd2KCmdID)nCmdID)
                 {
+                    case VSConstants.VSStd2KCmdID.RETURN:
+                        // Enter をエディタ側に流さず終了
+                        return VSConstants.S_OK;
+
                     case VSConstants.VSStd2KCmdID.BACKSPACE:
                         EditingCommands.Backspace.Execute(null, _input);
                         return VSConstants.S_OK;
+
                     case VSConstants.VSStd2KCmdID.DELETE:
                         EditingCommands.Delete.Execute(null, _input);
                         return VSConstants.S_OK;
+
                     case VSConstants.VSStd2KCmdID.LEFT:
                         EditingCommands.MoveLeftByCharacter.Execute(null, _input);
                         return VSConstants.S_OK;
+
                     case VSConstants.VSStd2KCmdID.RIGHT:
                         EditingCommands.MoveRightByCharacter.Execute(null, _input);
                         return VSConstants.S_OK;
+
                     case VSConstants.VSStd2KCmdID.UP:
                         EditingCommands.MoveUpByLine.Execute(null, _input);
                         return VSConstants.S_OK;
+
                     case VSConstants.VSStd2KCmdID.DOWN:
                         EditingCommands.MoveDownByLine.Execute(null, _input);
                         return VSConstants.S_OK;
                 }
             }
 
-            // ===== 2) VSStd97 コマンド（古い Delete など） =====
+            // VSStd97 コマンド（古い Delete）
             if (pguidCmdGroup == VSConstants.GUID_VSStandardCommandSet97 &&
                 (VSConstants.VSStd97CmdID)nCmdID == VSConstants.VSStd97CmdID.Delete)
             {
@@ -65,10 +82,9 @@ namespace Shine
                 return VSConstants.S_OK;
             }
 
-            // ===== 3) それ以外は次へ =====
+            // それ以外は次へ
             return _next?.Exec(ref pguidCmdGroup, nCmdID, nCmdexecopt, pvaIn, pvaOut)
                    ?? VSConstants.S_OK;
         }
-        #endregion
     }
 }


### PR DESCRIPTION
`InlineChatKeyFilter.cs` で `using System.Windows.Input;` を削除し、`QueryStatus` および `Exec` メソッドの引数を複数行に分割しました。これにより可読性が向上しました。また、`Exec` メソッド内のコメントを修正し、`RETURN` コマンドの処理を追加して、エディタ側に Enter キーの入力を流さないようにしました。全体的にコードの可読性と機能性が向上しています。